### PR TITLE
Fix cuda powfi error

### DIFF
--- a/xtrack/beam_elements/elements_src/linesegmentmap.h
+++ b/xtrack/beam_elements/elements_src/linesegmentmap.h
@@ -160,7 +160,7 @@ void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
             double phase = 2*PI*(qx + det_xx * J_x + det_xy * J_y);
             for (int i_dqx=1; i_dqx<ndqx; i_dqx++){
                 phase += 2*PI*(LineSegmentMapData_get_coeffs_dqx(el, i_dqx) *
-                               pow(LocalParticle_get_delta(part), i_dqx));
+                               pow(LocalParticle_get_delta(part), (double)i_dqx));
             }
 
             cos_x = cos(phase);
@@ -168,7 +168,7 @@ void transverse_motion(LocalParticle *part0, LineSegmentMapData el){
             phase = 2*PI*(qy + det_yx * J_x + det_yy * J_y);
             for (int i_dqy=1; i_dqy<ndqy; i_dqy++){
                 phase += 2*PI*(LineSegmentMapData_get_coeffs_dqy(el, i_dqy) *
-                               pow(LocalParticle_get_delta(part), i_dqy));
+                               pow(LocalParticle_get_delta(part), (double)i_dqy));
             }
 
             cos_y = cos(phase);


### PR DESCRIPTION
@lgiacome 

There's an issue on CUDA when calling `pow` with mixed arguments (see https://github.com/xsuite/xsuite/actions/runs/8636541153/job/23693656668), but I think this should fix it.